### PR TITLE
Add image zoom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Then you are ready to go!
 
 `Figure.vue`: An image or figure template. Includes structure to include size and type options to fit the viewport and device type. 
 
+`ImageZoom.vue`: A template for including a zoomable image. The image is zoomable with mouse scroll wheel, trackpad, touchscreen, or using zoom buttons. To use `main.js` needs to be modified to include `import VueZoomer from 'vue-zoomer';` and `Vue.use(VueZoomer);`:
+  * <img src="https://user-images.githubusercontent.com/54007288/200002258-e21a3a77-67f6-47a7-b067-f346e1764d28.png" height="300">
+
 ## Disclaimer
 
 This software is in the public domain because it contains materials that originally came from the U.S. Geological Survey, an agency of the United States Department of Interior. For more information, see the official USGS copyright policy at [http://www.usgs.gov/visual-id/credit_usgs.html#copyright](http://www.usgs.gov/visual-id/credit_usgs.html#copyright)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13249,6 +13249,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
+    "vue-zoomer": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/vue-zoomer/-/vue-zoomer-0.3.10.tgz",
+      "integrity": "sha512-wfdiGpCJVNvCGbD0YCaVbE0m8hlw3VWWp8L5baRfe8VvSSTYG568r6KO6KsksSpOPTywLRCctIEP8Ctxfdb8Kg=="
+    },
     "vuetify": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.7.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "vue-loader": "14.2.2",
     "vue-mobile-detection": "^1.0.0",
     "vue-router": "^3.5.4",
+    "vue-zoomer": "^0.3.10",
     "vuetify": "^2.6.6",
     "vuex": "^3.5.1",
     "webpack": "^4.42.0"

--- a/src/components/ImageZoom.vue
+++ b/src/components/ImageZoom.vue
@@ -5,7 +5,7 @@
         id="button-container"
         class="buttonContainer"
       >
-        <h3>
+        <h3 id="optionsBar">
           <span>
             Zoom:
             <button
@@ -79,6 +79,9 @@ export default {
 #image-zoomer {
   height: 85vh;
 }
+#optionsBar {
+  padding: .1em 0 .1em 0;
+}
 #button-container {
   padding-left: 15px;
   height: 100%;
@@ -94,8 +97,7 @@ export default {
 }
 .button {
   border-radius: 0.25rem;
-  margin-right: 2px;
-  margin-top: 2px;
+  margin: 2px 2px 7px 0;
   padding: 2.5px 5px 2.5px 5px;
   max-width: 24rem;
   background-color: white;

--- a/src/components/ImageZoom.vue
+++ b/src/components/ImageZoom.vue
@@ -1,0 +1,121 @@
+<template>
+  <section>
+    <div id="content-container">
+      <div
+        id="button-container"
+        class="buttonContainer"
+      >
+        <h3>
+          <span>
+            Zoom:
+            <button
+              class="zoom button"
+              @click="$refs.zoomer.zoomIn()"
+            > + </button>
+            <button
+              class="zoom button"
+              @click="$refs.zoomer.zoomOut()"
+            > - </button>
+          </span> 
+        </h3>
+      </div>
+      <v-zoomer
+        id="image-zoomer"
+        ref="zoomer"
+        :aspect-ratio="imageAspectRatio"
+        :max-scale="10"
+        :zooming-elastic="false"
+        class="content"
+      >
+        <picture>
+          <source
+            :srcset="imageSrcWebp"
+            type="image/webp"
+          >
+          <source
+            :srcset="imageSrc"
+            type="image/png"
+          >
+          <img
+            :src="imageSrcWebp"
+            style="object-fit: contain; width: 100%; height: 100%; display: flex;"
+            @load="onImageLoad"
+          >
+        </picture>
+      </v-zoomer>
+    </div>
+  </section>
+</template>
+<script>
+export default {
+  name: "ImageZoom",
+    components: {
+        //flowers
+    },
+    data() {
+    return {
+      zoomed: false,
+      imageAspectRatio: 1,
+      imageSrc: null,
+      imageSrcWebp: null
+    }
+  },
+  mounted(){
+      this.imageSrc = "https://labs.waterdata.usgs.gov/visualizations/images/USGS_WaterCycle_English_ONLINE.png";
+      this.imageSrcWebp = "https://labs.waterdata.usgs.gov/visualizations/images/USGS_WaterCycle_English_ONLINE.png";
+
+    },
+    methods:{
+      onImageLoad(e) {
+            const img = e.target
+            this.imageAspectRatio = img.naturalWidth / img.naturalHeight
+          },
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+#image-zoomer {
+  height: 85vh;
+}
+#button-container {
+  padding-left: 15px;
+  height: 100%;
+  z-index: 2;
+  --tw-bg-opacity: 1;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+      -moz-user-select: none; /* Old versions of Firefox */
+      -ms-user-select: none; /* Internet Explorer/Edge */
+          user-select: none; /* Non-prefixed version, currently
+                                supported by Chrome, Edge, Opera and Firefox */
+}
+.button {
+  border-radius: 0.25rem;
+  margin-right: 2px;
+  margin-top: 2px;
+  padding: 2.5px 5px 2.5px 5px;
+  max-width: 24rem;
+  background-color: white;
+  border: 0.5px solid #949494;
+  border-radius: 0.25rem;
+  margin-left: 0.5rem;
+  margin-top: 0.5rem;
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE 10 and IE 11 */
+  user-select: none; /* Standard syntax */
+}
+.button:hover {
+  background-color: #6E6E6E;
+  color: white;
+  @media screen and (max-width: 600px) {
+    background-color: white;
+    color: black;
+  }
+}
+.button.zoom {
+  padding: 2.5px 10px 2.5px 10px;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import VueCarousel from 'vue-carousel';
 import VueImg from 'v-img';
 import VueSvg from 'vue-svg-loader';
 import gsap from "gsap";
+import VueZoomer from 'vue-zoomer'
 
 
 // social icons
@@ -46,6 +47,7 @@ Vue.use(browserDetect);
 Vue.use(Vuetify);
 Vue.use(VueCarousel);
 Vue.use(VueImg, vueImgConfig);
+Vue.use(VueZoomer)
 
 
 const app = new Vue({

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="visualization">
-    <Rain />
+    <ImageZoom />
   </div>
 </template>
 
@@ -9,7 +9,7 @@
 export default {
     name: 'Visualization',
     components: {
-      Rain: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/rain")
+      ImageZoom: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/ImageZoom")
     },
     computed: {
     },


### PR DESCRIPTION
This PR adds in a component that allows for zoom on an image, as used [here](https://labs.waterdata.usgs.gov/visualizations/water-cycle/index.html#/).

It uses the [`vue-zoomer'](https://www.npmjs.com/package/vue-zoomer) package, which allows for mouse or touch zoom.

The component includes a zoomable image (with mouse scroll wheel [zooms to mouse location], trackpad or touch) and buttons to zoom in and out.