### PR TITLE
Authorship component

### DIFF
--- a/src/assets/text/authors.js
+++ b/src/assets/text/authors.js
@@ -1,4 +1,6 @@
 export default {
+    // do not delete section. delete individuals as needed. modify content as needed
+    // currently only 'fullName', 'firstName', 'initials', 'profile_link', and 'contribution' are used
     primaryAuthors: [
       {
         firstName: 'Althea1',
@@ -28,6 +30,8 @@ export default {
         contribution: 'made the charts'
       }
     ],
+    // do not delete section. delete any or all individuals as needed. modify content as needed
+    // currently only 'fullName', 'firstName', 'initials', 'profile_link', and 'contribution' are used
     additionalAuthors: [
       {
         firstName: 'Cee',

--- a/src/assets/text/authors.js
+++ b/src/assets/text/authors.js
@@ -1,0 +1,78 @@
+export default {
+    primaryAuthors: [
+      {
+        firstName: 'Althea1',
+        lastName: 'Archer',
+        fullName: 'Althea Archer1',
+        initials: 'AA1',
+        profile_link: 'https://www.usgs.gov/staff-profiles/althea-archer',
+        role: 'lead developer',
+        contribution: 'led the design and development of the Vue website'
+      },
+      {
+        firstName: 'Althea2',
+        lastName: 'Archer',
+        fullName: 'Althea Archer2',
+        initials: 'AA2',
+        profile_link: 'https://www.usgs.gov/staff-profiles/althea-archer',
+        role: 'lead developer',
+        contribution: 'designed the illustrations'
+      },
+      {
+        firstName: 'Althea3',
+        lastName: 'Archer',
+        fullName: 'Althea Archer3',
+        initials: 'AA3',
+        profile_link: 'https://www.usgs.gov/staff-profiles/althea-archer',
+        role: 'lead developer',
+        contribution: 'made the charts'
+      }
+    ],
+    additionalAuthors: [
+      {
+        firstName: 'Cee',
+        lastName: 'Nell',
+        fullName: 'Cee Nell',
+        initials: 'CN',
+        profile_link: 'https://www.usgs.gov/staff-profiles/cee-nell',
+        role: 'supervisor',
+        contribution: 'acted in an avisory role and reviewed code'
+      },
+      {
+        firstName: 'Hayley',
+        lastName: 'Corson-Dosch',
+        fullName: 'Hayley Corson-Dosch',
+        initials: 'HCD',
+        profile_link: 'https://www.usgs.gov/staff-profiles/hayley-corson-dosch',
+        role: 'contributor',
+        contribution: 'built the initial pipeline and reviewed code'
+      },
+      {
+        firstName: 'Elmera',
+        lastName: 'Azadpour',
+        fullName: 'Elmera Azadpour',
+        initials: 'EA',
+        profile_link: 'https://www.usgs.gov/staff-profiles/elmera-azadpour',
+        role: 'critiquer',
+        contribution: 'provided design critique'
+      },
+      {
+        firstName: 'Lindsay',
+        lastName: 'Platt',
+        fullName: 'Lindsay Platt',
+        initials: 'LP',
+        profile_link: 'https://www.usgs.gov/staff-profiles/lindsay-rc-platt',
+        role: 'critiquer',
+        contribution: 'helped set up the svg'
+      },
+      {
+        firstName: 'Mandie',
+        lastName: 'Carr',
+        fullName: 'Mandie Carr',
+        initials: 'MC',
+        profile_link: 'https://www.usgs.gov/staff-profiles/amanda-carr',
+        role: 'contributor',
+        contribution: 'provided design critique'
+      }
+      ]
+};

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -1,0 +1,7 @@
+<template>
+</template>
+
+<script>
+</script>
+<style>
+</style>

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -2,7 +2,7 @@
   <div id="author-container" v-if="showAuthors">
     <p>
       <span id="primary-author-statment">
-        The development was lead by 
+        The development of {{ appTitle }} was lead by 
         <span
           v-for="(author, index) in primaryAuthors" 
           :key="`${author.initials}-attribution`"
@@ -67,6 +67,7 @@ export default {
     data() {
       return {
         publicPath: process.env.BASE_URL, // allows the application to find the files when on different deployment roots
+        appTitle: process.env.VUE_APP_TITLE, // Pull in title of page from Vue environment (set in .env)
         mobileView: isMobile, // test for mobile
         primaryAuthors: authors.primaryAuthors,
         additionalAuthors: authors.additionalAuthors,
@@ -77,6 +78,7 @@ export default {
       }
     },
     mounted(){   
+      console.log(this.appTitle)
       this.showAuthors = this.primaryAuthors.length > 0 ? true: false; // Show author statements for any authors
       this.showAdditionalAuthors =  this.additionalAuthors.length > 0 ? true : false; // Show author statements for additional authors if any are listed
       this.showAditionalContributionStatement = this.additionalAuthors.length > 0 ? true : false; // Show contributions statements for additional authors if any are listed AND showContributionStatements is true

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -1,57 +1,57 @@
 <template>
   <div id="author-container">
-        <p>
-        <span id="primary-author-statment">
-          The development was lead by 
-          <span
-            v-for="(author, index) in primaryAuthors" 
-            :key="`${author.initials}-attribution`"
-            :id="`initial-${author.initials}`"
-            :class="'author first'"
-          >
+    <p>
+      <span id="primary-author-statment">
+        The development was lead by 
+        <span
+          v-for="(author, index) in primaryAuthors" 
+          :key="`${author.initials}-attribution`"
+          :id="`initial-${author.initials}`"
+          :class="'author first'"
+        >
           <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a>
           <span v-if="index != Object.keys(primaryAuthors).length - 1 && Object.keys(primaryAuthors).length > 2">, </span>
-            <span v-if="index == Object.keys(primaryAuthors).length - 2"> and </span>
-          </span>.
+          <span v-if="index == Object.keys(primaryAuthors).length - 2"> and </span>
+        </span>.
+      </span>
+      <span id="additional-author-statement" v-if="showAdditionalAuthors">
+        <span
+          v-for="(author, index) in additionalAuthors" 
+          :key="`${author.initials}-attribution`"
+          :id="`author-${author.initials}`"
+          :class="'author'"
+        >
+          <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a>
+          <span v-if="index != Object.keys(additionalAuthors).length - 1 && Object.keys(additionalAuthors).length > 2">, </span>
+          <span v-if="index == Object.keys(additionalAuthors).length - 2"> and </span>
         </span>
-        <span id="additional-author-statement" v-if="showAdditionalAuthors">
+        <span>
+        also contributed to the site.
+        </span>
+      </span>
+      <span id="contribution-statements" v-if="showContributionStatements">
+        <span id="primary-author-contribution">
           <span
-            v-for="(author, index) in additionalAuthors" 
-            :key="`${author.initials}-attribution`"
+            v-for="author in primaryAuthors" 
+            :key="`${author.initials}-contribution`"
             :id="`author-${author.initials}`"
             :class="'author'"
           >
-            <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a>
-            <span v-if="index != Object.keys(additionalAuthors).length - 1 && Object.keys(additionalAuthors).length > 2">, </span>
-            <span v-if="index == Object.keys(additionalAuthors).length - 2"> and </span>
-          </span>
-          <span>
-          also contributed to the site.
+            <span v-text="author.firstName"> </span> <span v-text="author.contribution"></span>. 
           </span>
         </span>
-        <span id="contribution-statements" v-if="showContributionStatements">
-          <span id="primary-author-contribution">
-            <span
-              v-for="author in primaryAuthors" 
-              :key="`${author.initials}-contribution`"
-              :id="`author-${author.initials}`"
-              :class="'author'"
-            >
-              <span v-text="author.firstName"> </span> <span v-text="author.contribution"></span>. 
-            </span>
-          </span>
-          <span id="additional-author-contribution"  v-if="showAditionalContributionStatement">
-            <span
-              v-for="author in additionalAuthors" 
-              :key="`${author.initials}-contribution`"
-              :id="`author-${author.initials}`"
-              :class="'author'"
-            >
-              <span v-text="author.firstName"> </span> <span v-text="author.contribution"></span>. 
-            </span>
+        <span id="additional-author-contribution"  v-if="showAditionalContributionStatement">
+          <span
+            v-for="author in additionalAuthors" 
+            :key="`${author.initials}-contribution`"
+            :id="`author-${author.initials}`"
+            :class="'author'"
+          >
+            <span v-text="author.firstName"> </span> <span v-text="author.contribution"></span>. 
           </span>
         </span>
-        </p>
+      </span>
+    </p>
   </div>
 </template>
 
@@ -70,8 +70,8 @@ export default {
         mobileView: isMobile, // test for mobile
         primaryAuthors: authors.primaryAuthors,
         additionalAuthors: authors.additionalAuthors,
-        showAdditionalAuthors: null,
-        showContributionStatements: true, // Turn on or off contriubtion statements for ALL authors
+        showAdditionalAuthors: null, // Turn on or off attribution for additional authors
+        showContributionStatements: true, // Turn on or off contribution statements for ALL authors
         showAditionalContributionStatement: null // if showContributionStatements is true, turn on or off contriubtion statements for ADDITIONAL authors
       }
     },

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="author-container">
+  <div id="author-container" v-if="showAuthors">
     <p>
       <span id="primary-author-statment">
         The development was lead by 
@@ -70,12 +70,14 @@ export default {
         mobileView: isMobile, // test for mobile
         primaryAuthors: authors.primaryAuthors,
         additionalAuthors: authors.additionalAuthors,
-        showAdditionalAuthors: null, // Turn on or off attribution for additional authors
-        showContributionStatements: true, // Turn on or off contribution statements for ALL authors
-        showAditionalContributionStatement: null // if showContributionStatements is true, turn on or off contriubtion statements for ADDITIONAL authors
+        showAuthors: null, // Turn on or off attribution for all authors
+        showAdditionalAuthors: null, // If showAuthors is true, turn on or off attribution for additional authors
+        showContributionStatements: true, // If showAuthors is true, turn on or off contribution statements for ALL authors
+        showAditionalContributionStatement: null // If showAuthors is true and if showContributionStatements is true, turn on or off contriubtion statements for ADDITIONAL authors
       }
     },
     mounted(){   
+      this.showAuthors = this.primaryAuthors.length > 0 ? true: false; // Show author statements for any authors
       this.showAdditionalAuthors =  this.additionalAuthors.length > 0 ? true : false; // Show author statements for additional authors if any are listed
       this.showAditionalContributionStatement = this.additionalAuthors.length > 0 ? true : false; // Show contributions statements for additional authors if any are listed AND showContributionStatements is true
     },

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -1,7 +1,98 @@
 <template>
+  <div id="author-container">
+        <p>
+        <span id="primary-author-statment">
+          The development was lead by 
+          <span
+            v-for="(author, index) in primaryAuthors" 
+            :key="`${author.initials}-attribution`"
+            :id="`initial-${author.initials}`"
+            :class="'author first'"
+          >
+          <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a>
+          <span v-if="index != Object.keys(primaryAuthors).length - 1 && Object.keys(primaryAuthors).length > 2">, </span>
+            <span v-if="index == Object.keys(primaryAuthors).length - 2"> and </span>
+          </span>.
+        </span>
+        <span id="additional-author-statement" v-if="showAdditionalAuthors">
+          <span
+            v-for="(author, index) in additionalAuthors" 
+            :key="`${author.initials}-attribution`"
+            :id="`author-${author.initials}`"
+            :class="'author'"
+          >
+            <a v-bind:href="author.profile_link" target="_blank" v-text="author.fullName"></a>
+            <span v-if="index != Object.keys(additionalAuthors).length - 1 && Object.keys(additionalAuthors).length > 2">, </span>
+            <span v-if="index == Object.keys(additionalAuthors).length - 2"> and </span>
+          </span>
+          <span>
+          also contributed to the site.
+          </span>
+        </span>
+        <span id="contribution-statements" v-if="showContributionStatements">
+          <span id="primary-author-contribution">
+            <span
+              v-for="author in primaryAuthors" 
+              :key="`${author.initials}-contribution`"
+              :id="`author-${author.initials}`"
+              :class="'author'"
+            >
+              <span v-text="author.firstName"> </span> <span v-text="author.contribution"></span>. 
+            </span>
+          </span>
+          <span id="additional-author-contribution"  v-if="showAditionalContributionStatement">
+            <span
+              v-for="author in additionalAuthors" 
+              :key="`${author.initials}-contribution`"
+              :id="`author-${author.initials}`"
+              :class="'author'"
+            >
+              <span v-text="author.firstName"> </span> <span v-text="author.contribution"></span>. 
+            </span>
+          </span>
+        </span>
+        </p>
+  </div>
 </template>
 
 <script>
+import { isMobile } from 'mobile-device-detect';
+import authors from "@/assets/text/authors";
+export default {
+  name: "authorship",
+    components: {
+    },
+    props: {
+    },
+    data() {
+      return {
+        publicPath: process.env.BASE_URL, // allows the application to find the files when on different deployment roots
+        mobileView: isMobile, // test for mobile
+        primaryAuthors: authors.primaryAuthors,
+        additionalAuthors: authors.additionalAuthors,
+        showAdditionalAuthors: null,
+        showContributionStatements: true, // Turn on or off contriubtion statements for ALL authors
+        showAditionalContributionStatement: null // if showContributionStatements is true, turn on or off contriubtion statements for ADDITIONAL authors
+      }
+    },
+    mounted(){   
+      this.showAdditionalAuthors =  this.additionalAuthors.length > 0 ? true : false; // Show author statements for additional authors if any are listed
+      this.showAditionalContributionStatement = this.additionalAuthors.length > 0 ? true : false; // Show contributions statements for additional authors if any are listed AND showContributionStatements is true
+    },
+    methods:{
+      isMobile() {
+              if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+                  return true
+              } else {
+                  return false
+              }
+          }
+    }
+}
 </script>
 <style>
+#author-container {
+  height: auto;
+  padding: 10px 0 10px 0;
+}
 </style>

--- a/src/components/Authorship.vue
+++ b/src/components/Authorship.vue
@@ -93,6 +93,6 @@ export default {
 <style>
 #author-container {
   height: auto;
-  padding: 10px 0 10px 0;
+  padding: 10px 15px 10px 15px;
 }
 </style>

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="visualization">
-    <useDialogCard />
+    <authorship />
   </div>
 </template>
 
@@ -9,7 +9,7 @@
 export default {
     name: 'Visualization',
     components: {
-      useDialogCard: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/UseDialogCard")
+      authorship: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/Authorship")
     },
     computed: {
     },


### PR DESCRIPTION
This sets up a new authorship component for us to use moving forward. It is set up such that there can be a 1+ 'primary' and 0+ 'additional' authors. The component can be updated by adding or removing primary and additional authors in `src/assets/text/authors.js` or modifying existing names/contributions. At the moment, only the author names, profile links, initials, and contribution information are used.

I've set up `v-if` statements that dynamically show or hide the attribution statement for the additional authors based on whether or not additional authors are defined in `src/assets/text/authors.js`. I've also set up `v-if` statements to control whether _any_ contribution statements are shown and also if they are shown, whether contribution statements are shown for the additional authors.

TBD on where and how this makes sense to be inserted into our sites.

To run, pull this branch to your local machine and run `npm run serve` in your development IDE.

![image](https://user-images.githubusercontent.com/54007288/201223263-87c29f76-0781-4555-bcf1-27560af41233.png)
